### PR TITLE
feat: Add Astralites showcase page

### DIFF
--- a/astralites/index.html
+++ b/astralites/index.html
@@ -1,0 +1,464 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <title>Astralites Showcase | FrozenFox</title>
+    <link rel="stylesheet" href="../css/main.css">
+    <link rel="stylesheet" href="../css/astralites.css">
+    <link rel="stylesheet" href="../css/showcase.css">
+    <link rel="icon" href="../media/branding/favicon.ico">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="custom-cursor"></div>
+    <div class="cursor-follower"></div>
+    <header>
+        <div class="container">
+            <div class="branding">
+                <div class="logo-container">
+                  <img src="../media/branding/logo.png" alt="FrozenFox Logo" class="logo">
+                  <span class="hidden-text">HI!</span>
+                </div>
+                <h1>Frozen<span>Fox</span></h1>
+              </div>
+            <nav>
+                <ul>
+                    <li><a href="../index.html">Home</a></li>
+                    <li class="current dropdown">
+                        <a href="../showcase.html" class="dropdown-btn">Showcase</a>
+                        <div class="dropdown-content">
+                            <a href="../starsmp/">
+                                <img src="../media/starsmp/staricons/ice.png" alt="Star SMP">
+                                <span>Star SMP</span>
+                            </a>
+                            <a href="../astralites/">
+                                <img src="../media/branding/logo.png" alt="Astralites">
+                                <span>Astralites</span>
+                            </a>
+                        </div>
+                    </li>
+                    <li><a href="../contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+
+    <section class="starsmp-hero">
+        <div class="container">
+            <h1>Astralites Plugin</h1>
+            <p>A hardcore survival experience with a unique twist.</p>
+            <div class="smalltext"><small>This is just a demonstation of my skills, this plugin is not for sale.</small></div>
+        </div>
+    </section>
+
+    <section class="star-categories">
+        <div class="container">
+            <div class="category-tabs">
+                <button class="tab-btn active" data-category="annihilators">The Annihilators</button>
+                <button class="tab-btn" data-category="controllers">The Controllers</button>
+                <button class="tab-btn" data-category="harbingers">The Harbingers</button>
+            </div>
+
+            <div class="category-content active" id="annihilators">
+                <!-- SUPERNOVA STAR -->
+                <div class="star-card" data-star="supernova">
+                    <div class="star-header">
+                        <div class="star-name-container">
+                            <h2>SUPERNOVA STAR</h2>
+                        </div>
+                    </div>
+                    <div class="star-content">
+                        <div class="star-abilities">
+                            <div class="ability">
+                                <p>Become the heart of a dying star. You are a walking cataclysm, capable of unleashing one of the most destructive forces in the universe. But wield this power with caution, for its magnitude is matched only by its danger.</p>
+                                <h3>Ability: Cataclysmic Detonation</h3>
+                                <p>After a 5-second charge, you explode in a massive 15-block radius, dealing catastrophic damage (8-10 hearts) to all nearby entities.</p>
+                                <h3>Death Trigger</h3>
+                                <p>If you are killed while charging, your body becomes a martyr's bomb, triggering the supernova upon death.</p>
+                                <h3>Cooldown</h3>
+                                <p>This ultimate power can only be used once every 5 Minecraft days.</p>
+                            </div>
+                        </div>
+                        <div class="star-media">
+                            <div class="video-pair">
+                                <video controls>
+                                    <source src="../media/astralitessmp/SupernovaReplay.mp4" type="video/mp4">
+                                    Your browser does not support the video tag.
+                                </video>
+                                <p>Replay view</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- RAGNAROK STAR -->
+                <div class="star-card" data-star="ragnarok">
+                    <div class="star-header">
+                        <div class="star-name-container">
+                            <h2>RAGNAROK STAR</h2>
+                        </div>
+                    </div>
+                    <div class="star-abilities">
+                        <div class="ability">
+                            <p>Unleash the end of days. For a brief, terrifying period, you become a harbinger of the apocalypse, tearing the world apart around you. This power comes at a great personal cost, chipping away at your very life force with each use.</p>
+                            <h3>Ability: The Final Hour</h3>
+                            <p>For 10 seconds, you summon a storm of destruction. Random lightning strikes and chaotic explosions erupt in a 12-block radius around you.</p>
+                            <h3>Ultimate Sacrifice</h3>
+                            <p>Each use of this ability permanently removes 1 heart from your maximum health.</p>
+                            <h3>Cooldown</h3>
+                            <p>Can be used once every 2 Minecraft days.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- METEOR STAR -->
+                <div class="star-card" data-star="meteor">
+                    <div class="star-header">
+                        <div class="star-name-container">
+                            <h2>METEOR STAR</h2>
+                        </div>
+                    </div>
+                     <div class="star-content">
+                        <div class="star-abilities">
+                            <div class="ability">
+                                <p>Call down the heavens' wrath. Command a volley of celestial rocks to bombard your enemies from above, turning the battlefield into a cratered wasteland.</p>
+                                <h3>Ability: Meteor Shower</h3>
+                                <p>Summons 3-5 small meteors that crash down randomly in a 10-block radius around your target.</p>
+                                <h3>Impact</h3>
+                                <p>Each meteor deals 2.5 hearts on direct hit and explodes with the force of a small creeper blast, potentially setting the ground ablaze.</p>
+                                <h3>Cooldown</h3>
+                                <p>50 seconds.</p>
+                            </div>
+                        </div>
+                        <div class="star-media">
+                            <div class="video-pair">
+                                <video controls>
+                                    <source src="../media/astralitessmp/MeteorReplay.mp4" type="video/mp4">
+                                    Your browser does not support the video tag.
+                                </video>
+                                <p>Replay view</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- BURN STAR -->
+                <div class="star-card" data-star="burn">
+                    <div class="star-header">
+                        <div class="star-name-container">
+                            <h2>BURN STAR</h2>
+                        </div>
+                    </div>
+                    <div class="star-abilities">
+                        <div class="ability">
+                            <p>Embody the eternal flame. You are a living inferno. Summon a searing explosion and walk through fire as if it were air, your power waxing in the light of the sun.</p>
+                            <h3>Ability: Fire Nova</h3>
+                            <p>Unleash a fiery explosion in a 6-block radius, dealing 3-4 hearts of damage and setting everything ablaze with a Fire Aspect II burn.</p>
+                            <h3>User Buffs</h3>
+                            <p>For 10 seconds after activation, you are immune to fire and lava. Additionally, you deal 20% increased melee damage while in direct daylight.</p>
+                            <h3>Cooldown</h3>
+                            <p>45 seconds.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- SUNLIGHT STAR -->
+                <div class="star-card" data-star="sunlight">
+                    <div class="star-header">
+                        <div class="star-name-container">
+                            <h2>SUNLIGHT STAR</h2>
+                        </div>
+                    </div>
+                    <div class="star-abilities">
+                        <div class="ability">
+                            <p>Wield a beam of pure solar energy. Fire a concentrated laser of sunlight that pierces through your foes, leaving them scorched and blinded by your brilliance.</p>
+                            <h3>Ability: Solar Beam</h3>
+                            <p>Fires a 20-block laser that pierces up to three enemies, dealing a massive 6 hearts of damage and inflicting Blindness for 30 seconds.</p>
+                            <h3>Sunlight Affinity</h3>
+                            <p>The ability's cooldown charges 50% faster when you are standing in direct sunlight.</p>
+                            <h3>Cooldown</h3>
+                            <p>40 seconds.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="category-content" id="controllers">
+                <!-- STAR WARDEN -->
+                <div class="star-card" data-star="starwarden">
+                    <div class="star-header">
+                        <div class="star-name-container">
+                            <h2>STAR WARDEN</h2>
+                        </div>
+                    </div>
+                    <div class="star-abilities">
+                        <div class="ability">
+                            <p>Command the irresistible pull of a black hole. You bend gravity to your will, creating a singularity that traps your enemies and tears them apart.</p>
+                            <h3>Ability: Event Horizon</h3>
+                            <p>For 15 seconds, create a black hole that pulls in mobs, players, projectiles, and items within a 30-block radius. Anything caught in the epicenter takes a devastating 10 hearts of damage per second.</p>
+                            <h3>User Buffs</h3>
+                            <p>You take 75% less fall damage, but your own gravitational pull causes you to fall 25% faster.</p>
+                            <h3>Cooldown</h3>
+                            <p>60 seconds.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- NEBULA STAR -->
+                <div class="star-card" data-star="nebula">
+                    <div class="star-header">
+                        <div class="star-name-container">
+                            <h2>NEBULA STAR</h2>
+                        </div>
+                    </div>
+                    <div class="star-abilities">
+                        <div class="ability">
+                            <p>Become a living storm of cosmic dust. Shroud yourself in a swirling nebula that confounds and withers your enemies, making you a fortress against projectiles.</p>
+                            <h3>Ability: Ender's Mist</h3>
+                            <p>For 12 seconds, you are surrounded by a 7-block wide fog. Enemies inside are afflicted with Slowness II, Blindness, and Wither I. All enemy projectiles that enter the mist are nullified.</p>
+                            <h3>Downside</h3>
+                            <p>Your movement speed is reduced by 20% while the nebula is active.</p>
+                            <h3>Cooldown</h3>
+                            <p>45 seconds.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- FREEZE STAR -->
+                <div class="star-card" data-star="freeze">
+                    <div class="star-header">
+                        <div class="star-name-container">
+                            <h2>FREEZE STAR</h2>
+                        </div>
+                    </div>
+                     <div class="star-content">
+                        <div class="star-abilities">
+                            <div class="ability">
+                                <p>Stop your enemy in the river of time. Isolate a single foe, locking them in a timeless prison. They are safe from harm while frozen, but once time resumes, the entirety of their deferred fate is dealt at once.</p>
+                                <h3>Ability: Time Lock</h3>
+                                <p>Target an enemy within 15 blocks, freezing them for 5 seconds. The target is invulnerable but cannot move or act. All damage they would have taken is queued and applied instantly when the effect ends.</p>
+                                <h3>Cooldown</h3>
+                                <p>15 seconds.</p>
+                            </div>
+                        </div>
+                        <div class="star-media">
+                            <div class="video-pair">
+                                <video controls>
+                                    <source src="../media/astralitessmp/FreezeReplay.mp4" type="video/mp4">
+                                    Your browser does not support the video tag.
+                                </video>
+                                <p>Replay view</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- CRUSH STAR -->
+                <div class="star-card" data-star="crush">
+                    <div class="star-header">
+                        <div class="star-name-container">
+                            <h2>CRUSH STAR</h2>
+                        </div>
+                    </div>
+                    <div class="star-content">
+                        <div class="star-abilities">
+                            <div class="ability">
+                                <p>Dominate your personal space with gravitational force. First, you pull all nearby foes into your grasp, then you violently expel them, using gravity as both a net and a hammer.</p>
+                                <h3>Ability: Pull and Repel</h3>
+                                <p>A two-step ability. First, all enemies within a 12-block radius are dragged towards you for 2 seconds. This is immediately followed by a violent knockback, launching them 8 blocks away and inflicting 2 hearts of fall damage.</p>
+                                <h3>Cooldown</h3>
+                                <p>50 seconds.</p>
+                            </div>
+                        </div>
+                        <div class="star-media">
+                            <div class="video-pair">
+                                <video controls>
+                                    <source src="../media/astralitessmp/CrushReplay.mp4" type="video/mp4">
+                                    Your browser does not support the video tag.
+                                </video>
+                                <p>Replay view</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- SOLAR STAR -->
+                <div class="star-card" data-star="solar">
+                    <div class="star-header">
+                        <div class="star-name-container">
+                            <h2>SOLAR STAR</h2>
+                        </div>
+                    </div>
+                    <div class="star-abilities">
+                        <div class="ability">
+                            <p>Unleash a blinding flash of stellar light. A close-range defensive burst, perfect for disorienting aggressive enemies and creating an opportunity to escape or counter-attack.</p>
+                            <h3>Ability: Solar Flare</h3>
+                            <p>Erupt with a flash of light in a 6-block radius. It deals 1 heart of damage but inflicts nearby enemies with Blindness (5s) and Nausea (4s).</p>
+                            <h3>Cooldown</h3>
+                            <p>30 seconds.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- SKY STAR -->
+                <div class="star-card" data-star="sky">
+                    <div class="star-header">
+                        <div class="star-name-container">
+                            <h2>SKY STAR</h2>
+                        </div>
+                    </div>
+                    <div class="star-abilities">
+                        <div class="ability">
+                            <p>Defy gravity only to come crashing down with immense force. Use the sky as your perch before slamming into the ground, sending a shockwave that devastates your foes.</p>
+                            <h3>Ability: Celestial Slam</h3>
+                            <p>Launch yourself 15 blocks into the air. Upon landing, you create a 6-block shockwave that deals 4-6 hearts of damage and knocks back all nearby enemies by 5 blocks.</p>
+                            <h3>Cooldown</h3>
+                            <p>35 seconds.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="category-content" id="harbingers">
+                <!-- CHAOS STAR -->
+                <div class="star-card" data-star="chaos">
+                    <div class="star-header">
+                        <div class="star-name-container">
+                            <h2>CHAOS STAR</h2>
+                        </div>
+                    </div>
+                    <div class="star-content">
+                        <div class="star-abilities">
+                            <div class="ability">
+                                <p>Embrace total randomness. Be the agent of cosmic uncertainty. Each activation is a gamble. Will you shower the world with riches, summon a powerful ally, or unleash a terrible monster upon yourself and your enemies?</p>
+                                <h3>Ability: Roll the Dice</h3>
+                                <p>When activated, a random event occurs:</p>
+                                <ul>
+                                    <li>30% Chance: Spawn random valuable loot.</li>
+                                    <li>30% Chance: Summon random hostile or friendly mobs.</li>
+                                    <li>20% Chance: Apply random potion effects to everyone nearby.</li>
+                                    <li>15% Chance: Create a dangerous anomaly, like a TNT explosion or lightning strike.</li>
+                                    <li>5% Chance: Spawn a Warden.</li>
+                                </ul>
+                                <h3>Cooldown</h3>
+                                <p>60 seconds.</p>
+                            </div>
+                        </div>
+                        <div class="star-media">
+                            <div class="video-pair">
+                                <video controls>
+                                    <source src="../media/astralitessmp/ChaosReplay.mp4" type="video/mp4">
+                                    Your browser does not support the video tag.
+                                </video>
+                                <p>Replay view</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- PACT STAR -->
+                <div class="star-card" data-star="pact">
+                    <div class="star-header">
+                        <div class="star-name-container">
+                            <h2>PACT STAR</h2>
+                        </div>
+                    </div>
+                    <div class="star-abilities">
+                        <div class="ability">
+                            <p>Make a blood pact for overwhelming power. Sacrifice your own life force for a brief window of godlike damage. Your only path to recovery is through victory.</p>
+                            <h3>Ability: Blood for Power</h3>
+                            <p>Instantly sacrifice 3 of your hearts to deal double damage for 10 seconds.</p>
+                            <h3>Reaping Clause</h3>
+                            <p>If you kill a player while the buff is active, your sacrificed hearts are immediately restored.</p>
+                            <h3>Cooldown</h3>
+                            <p>65 seconds.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- MIRROR STAR -->
+                <div class="star-card" data-star="mirror">
+                    <div class="star-header">
+                        <div class="star-name-container">
+                            <h2>MIRROR STAR</h2>
+                        </div>
+                    </div>
+                    <div class="star-abilities">
+                        <div class="ability">
+                            <p>Turn your enemy's strength against them. For a short duration, you become a reflective shield. A portion of all damage you take is instantly sent back to its source, with a chance to punish them even harder.</p>
+                            <h3>Ability: Damage Reversal</h3>
+                            <p>For 5 seconds, 50% of all incoming damage is reflected back to the attacker. There is a 20% chance that the reflected damage is doubled.</p>
+                            <h3>Cooldown</h3>
+                            <p>55 seconds.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- GRIMOIRE STAR -->
+                <div class="star-card" data-star="grimoire">
+                    <div class="star-header">
+                        <div class="star-name-container">
+                            <h2>GRIMOIRE STAR</h2>
+                        </div>
+                    </div>
+                    <div class="star-abilities">
+                        <div class="ability">
+                            <p>Wield a cursed book of unpredictable magic. You attempt to cast debilitating curses on your foes, but the Grimoire is fickle. There's an equal chance its chaotic magic will empower them instead.</p>
+                            <h3>Ability: Unstable Hex</h3>
+                            <p>Affects all enemies in an 8-block radius with random potion effects. There is a 50% chance the effects are harmful (e.g., Poison II, Slowness) and a 50% chance they are beneficial (e.g., Strength, Speed).</p>
+                            <h3>Cooldown</h3>
+                            <p>40 seconds.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- LIFELEECH STAR -->
+                <div class="star-card" data-star="lifeleech">
+                    <div class="star-header">
+                        <div class="star-name-container">
+                            <h2>LIFELEECH STAR</h2>
+                        </div>
+                    </div>
+                    <div class="star-content">
+                        <div class="star-abilities">
+                            <div class="ability">
+                                <p>Become a vampiric warrior, sustained by the vitality of your foes. This power allows you to drain health with every blow, but such dark magic constantly saps your own energy.</p>
+                                <h3>Ability: Vampiric Strikes</h3>
+                                <p>For 12 seconds, every melee hit you land steals 1.5 hearts from your enemy and heals you for the same amount.</p>
+                                <h3>Downside</h3>
+                                <p>While active, your hunger drains rapidly (1 bar every 4 seconds).</p>
+                                <h3>Cooldown</h3>
+                                <p>70 seconds.</p>
+                            </div>
+                        </div>
+                        <div class="star-media">
+                            <div class="video-pair">
+                                <video controls>
+                                    <source src="../media/astralitessmp/LifeLeechStar.mp4" type="video/mp4">
+                                    Your browser does not support the video tag.
+                                </video>
+                                <p>Replay view</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+    <section class="cta">
+        <div class="container">
+            <h2>Want a Plugin Like This?</h2>
+            <a href="../contact.html" class="btn">Contact FrozenFox</a>
+        </div>
+    </section>
+
+    <footer>
+        <div class="container">
+            <p>uhhhhhh.. hi!</p>
+        </div>
+    </footer>
+    <script src="../js/particles.js"></script>
+    <script src="../js/main.js"></script>
+</body>
+</html>

--- a/css/astralites.css
+++ b/css/astralites.css
@@ -1,0 +1,599 @@
+/* Astralites Showcase */
+.starsmp-hero {
+    position: relative;
+    padding: 180px 0 100px;
+    background: linear-gradient(135deg,
+        rgba(10, 14, 23, 0.9) 0%,
+        rgba(26, 34, 56, 0.8) 100%),
+        url('../media/starsmp/star-background.jpg') center/cover;
+    text-align: center;
+    overflow: hidden;
+}
+
+.starsmp-hero::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: radial-gradient(circle at center,
+        rgba(127, 211, 255, 0.2) 0%,
+        transparent 70%);
+    animation: pulse 8s ease infinite;
+}
+
+@keyframes pulse {
+    0%, 100% { transform: scale(1); opacity: 0.3; }
+    50% { transform: scale(1.2); opacity: 0.5; }
+}
+
+.starsmp-hero h1 {
+    font-size: 4rem;
+    margin-bottom: 20px;
+    background: linear-gradient(to right, var(--primary), var(--accent));
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    text-shadow: 0 2px 15px rgba(127, 211, 255, 0.3);
+    animation: textGlow 3s ease infinite alternate;
+}
+
+@keyframes textGlow {
+    from { text-shadow: 0 0 10px rgba(127, 211, 255, 0.3); }
+    to { text-shadow: 0 0 20px rgba(127, 211, 255, 0.6); }
+}
+
+.starsmp-hero p {
+    font-size: 1.4rem;
+    max-width: 800px;
+    margin: 0 auto 30px;
+    color: var(--text-light);
+}
+
+/* Category Tabs */
+.category-tabs {
+    display: flex;
+    justify-content: center;
+    margin: 40px 0;
+    gap: 15px;
+    flex-wrap: wrap;
+}
+
+.tab-btn {
+    padding: 15px 30px;
+    background: rgba(26, 34, 56, 0.7);
+    color: var(--text-light);
+    border: none;
+    border-radius: 50px;
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 700;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+    position: relative;
+    overflow: hidden;
+    z-index: 1;
+}
+
+.tab-btn::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(45deg, var(--primary), var(--accent));
+    z-index: -1;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.tab-btn.active::before,
+.tab-btn:hover::before {
+    opacity: 1;
+}
+
+.tab-btn:hover {
+    color: var(--dark) !important;
+}
+
+.tab-btn.active {
+    color: var(--dark);
+    box-shadow: 0 4px 20px var(--glow);
+}
+
+.tab-btn:hover:not(.active) {
+    color: var(--primary);
+    transform: translateY(-2px);
+}
+
+.category-content {
+    display: none;
+}
+
+.category-content.active {
+    display: block;
+    animation: fadeIn 0.5s ease;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+/* Star Cards */
+.star-card {
+    background: rgba(26, 34, 56, 0.8);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-radius: 16px;
+    padding: 40px;
+    margin-bottom: 40px;
+    border: 1px solid rgba(127, 211, 255, 0.15);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+    transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+    position: relative;
+    overflow: hidden;
+}
+
+.star-card::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: radial-gradient(circle at 20% 30%,
+        rgba(127, 211, 255, 0.1) 0%,
+        transparent 70%);
+    z-index: -1;
+}
+
+.star-card:hover {
+    transform: translateY(-10px);
+    box-shadow: 0 20px 50px var(--glow);
+    border-color: var(--accent);
+}
+
+.star-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 20px;
+    margin-bottom: 30px;
+    padding-bottom: 20px;
+    position: relative;
+}
+
+.star-header::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 2px;
+    background: linear-gradient(90deg,
+        transparent,
+        var(--primary),
+        transparent);
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform 0.6s ease;
+}
+
+.star-header h2 {
+    color: var(--primary);
+    font-size: 2rem;
+    margin: 0;
+    text-shadow: 0 2px 5px rgba(127, 211, 255, 0.2);
+}
+
+.star-icon {
+    width: 40px;
+    height: 40px;
+    object-fit: contain;
+    filter: drop-shadow(0 0 5px rgba(127, 211, 255, 0.5));
+    transform: scale(0.9);
+    transition: transform 0.3s ease;
+}
+
+.star-card:hover .star-icon {
+    transform: rotate(5deg) scale(1.0);
+}
+
+.star-type {
+    background: linear-gradient(45deg, var(--primary), var(--accent));
+    color: var(--dark);
+    padding: 8px 20px;
+    border-radius: 50px;
+    font-size: 0.9rem;
+    font-weight: 700;
+    white-space: nowrap;
+    box-shadow: 0 2px 10px rgba(127, 211, 255, 0.3);
+}
+
+.star-content {
+    display: flex;
+    gap: 30px;
+}
+
+.star-abilities {
+    flex: 1;
+}
+
+.ability {
+    background: rgba(26, 34, 56, 0.6);
+    padding: 25px;
+    border-radius: 12px;
+    border-left: 4px solid var(--primary);
+    transition: all 0.3s ease;
+    position: relative;
+    overflow: hidden;
+    backdrop-filter: blur(5px);
+    box-shadow: 0 10px 25px var(--dark);
+}
+
+.ability::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(135deg,
+        rgba(127, 211, 255, 0.05) 0%,
+        transparent 100%);
+    z-index: -1;
+}
+
+.ability:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 10px 25px var(--glow);
+    border-left-color: var(--accent);
+}
+
+.ability h3 {
+    color: var(--accent);
+    margin-top: 0;
+    margin-bottom: 15px;
+    font-size: 1.3rem;
+    position: relative;
+    display: inline-block;
+}
+
+.ability h3::after {
+    content: '';
+    position: absolute;
+    bottom: -5px;
+    left: 0;
+    width: 50px;
+    height: 2px;
+    background: var(--accent);
+    transition: width 0.3s ease;
+}
+
+.ability:hover h3::after {
+    width: 100%;
+}
+
+.ability p {
+    margin: 0;
+    color: var(--text-light);
+    line-height: 1.7;
+}
+
+.cooldown {
+    display: inline-block;
+    margin-top: 15px;
+    padding: 5px 12px;
+    background: rgba(127, 211, 255, 0.1);
+    border-radius: 20px;
+    color: var(--primary);
+    font-size: 0.8rem;
+    font-weight: 500;
+}
+
+.star-media {
+    flex: 1;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 20px;
+    align-content: start;
+}
+
+.video-pair {
+    margin-bottom: 20px;
+}
+
+.video-pair video {
+    width: 100%;
+    border-radius: 12px;
+    border: 2px solid transparent;
+    transition: all 0.3s ease, transform 0.3s;
+    box-shadow: 0 5px 20px rgba(0, 0, 0, 0.4);
+    background: #000;
+    display: block;
+}
+
+.video-pair:hover video {
+    border-color: var(--accent);
+    box-shadow: 0 15px 40px var(--glow);
+    transform: scale(1.02);
+}
+
+.video-pair p {
+    text-align: center;
+    margin-top: 5px;
+    font-size: 0.9rem;
+    color: var(--text-light);
+    transition: color 0.3s ease;
+}
+
+.star-media .image-pair {
+    text-align: center;
+    margin: 15px 0;
+}
+
+.star-media .image-pair img {
+    max-width: 100%;
+    border-radius: 8px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.image-pair:hover p {
+    color: var(--primary);
+}
+
+/* CTA Section */
+.cta {
+    background: linear-gradient(135deg,
+        rgba(127, 211, 255, 0.1) 0%,
+        rgba(26, 34, 56, 0.8) 100%);
+    padding: 80px 0;
+    text-align: center;
+    position: relative;
+    overflow: hidden;
+}
+
+.cta::before {
+    content: '';
+    position: absolute;
+    top: -50%;
+    left: -50%;
+    width: 200%;
+    height: 200%;
+    background: radial-gradient(circle at center,
+        var(--glow) 0%,
+        transparent 70%);
+    opacity: 0.3;
+    animation: rotate 20s linear infinite;
+    z-index: 0;
+}
+
+.cta .container {
+    position: relative;
+    z-index: 1;
+}
+
+.cta h2 {
+    font-size: 2.5rem;
+    margin-bottom: 20px;
+    color: var(--accent);
+    text-shadow: 0 2px 10px rgba(127, 211, 255, 0.3);
+}
+
+.cta p {
+    font-size: 1.2rem;
+    max-width: 700px;
+    margin: 0 auto 40px;
+    color: var(--text-light);
+}
+
+.cta .btn {
+    padding: 15px 50px;
+    font-size: 1.1rem;
+    border-radius: 50px;
+    position: relative;
+    overflow: hidden;
+    z-index: 1;
+}
+
+.cta .btn::before {
+    background: linear-gradient(45deg,
+        var(--primary),
+        var(--accent),
+        var(--primary));
+    animation: gradientShift 3s ease infinite;
+}
+
+.cta .btn:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 10px 30px var(--glow);
+}
+
+/* Responsive Design */
+@media (max-width: 1200px) {
+    .star-content {
+        flex-direction: column;
+    }
+    .star-media {
+        grid-template-columns: 1fr;
+        margin-top: 40px;
+    }
+}
+
+@media (max-width: 900px) {
+    .star-abilities {
+        grid-template-columns: 1fr;
+    }
+    .star-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+    .star-type {
+        margin-top: 15px;
+        align-self: flex-start;
+    }
+}
+
+@media (max-width: 768px) {
+    .starsmp-hero h1 {
+        font-size: 2.8rem;
+    }
+    .starsmp-hero p {
+        font-size: 1.1rem;
+    }
+    .category-tabs {
+        flex-direction: column;
+        align-items: center;
+    }
+    .tab-btn {
+        width: 100%;
+        max-width: 300px;
+    }
+    .star-card {
+        padding: 30px 20px;
+    }
+}
+
+@media (max-width: 600px) {
+    .star-abilities {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 480px) {
+    .starsmp-hero h1 {
+        font-size: 2.2rem;
+    }
+    .star-header h2 {
+        font-size: 1.6rem;
+    }
+    .ability {
+        padding: 20px 15px;
+    }
+}
+
+.star-name-container {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+code {
+    background: #f5f5f5;
+    padding: 2px 5px;
+    border-radius: 3px;
+    font-family: monospace;
+    color: #d63384;
+}
+
+.star-card h3 {
+    margin-top: 1.5em;
+}
+
+.star-card h3:first-child {
+    margin-top: 0;
+}
+
+@keyframes rotate {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+.star-card[data-star="supernova"] {
+    --glow: rgba(255, 80, 80, 0.45);
+    --primary: #ff3c3c;
+    --accent: #ff5050;
+}
+
+.star-card[data-star="ragnarok"] {
+    --glow: rgba(220, 40, 40, 0.45);
+    --primary: #d62828;
+    --accent: #dc2828;
+}
+
+.star-card[data-star="meteor"] {
+    --glow: rgba(255, 90, 0, 0.45);
+    --primary: #ff5e13;
+    --accent: #ff5a00;
+}
+
+.star-card[data-star="burn"] {
+    --glow: rgba(255, 120, 0, 0.45);
+    --primary: #ff8c13;
+    --accent: #ff8c00;
+}
+
+.star-card[data-star="sunlight"] {
+    --glow: rgba(255, 255, 120, 0.45);
+    --primary: #ffe94f;
+    --accent: #ffff78;
+}
+
+.star-card[data-star="starwarden"] {
+    --glow: rgba(120, 80, 160, 0.35);
+    --primary: #bba3d4;
+    --accent: #7850a0;
+}
+
+.star-card[data-star="nebula"] {
+    --glow: rgba(160, 80, 200, 0.35);
+    --primary: #bba3d4;
+    --accent: #a050c8;
+}
+
+.star-card[data-star="freeze"] {
+    --glow: rgba(80, 200, 255, 0.45);
+    --primary: #4fdcff;
+    --accent: #50c8ff;
+}
+
+.star-card[data-star="crush"] {
+    --glow: rgba(180, 240, 255, 0.45);
+    --primary: #e3f6fd;
+    --accent: #b4f0ff;
+}
+
+.star-card[data-star="solar"] {
+    --glow: rgba(255, 255, 120, 0.45);
+    --primary: #ffe94f;
+    --accent: #ffff78;
+}
+
+.star-card[data-star="sky"] {
+    --glow: rgba(180, 240, 255, 0.45);
+    --primary: #e3f6fd;
+    --accent: #b4f0ff;
+}
+
+.star-card[data-star="chaos"] {
+    --glow: rgba(120, 0, 255, 0.45);
+    --primary: #7c3aed;
+    --accent: #7800ff;
+}
+
+.star-card[data-star="pact"] {
+    --glow: rgba(220, 20, 60, 0.45);
+    --primary: #dc143c;
+    --accent: #dc143c;
+}
+
+.star-card[data-star="mirror"] {
+    --glow: rgba(200, 200, 255, 0.45);
+    --primary: #e0e0e0;
+    --accent: #c8c8ff;
+}
+
+.star-card[data-star="grimoire"] {
+    --glow: rgba(160, 80, 255, 0.45);
+    --primary: #a259ff;
+    --accent: #a050ff;
+}
+
+.star-card[data-star="lifeleech"] {
+    --glow: rgba(255, 80, 80, 0.45);
+    --primary: #ff3c3c;
+    --accent: #ff5050;
+}

--- a/showcase.html
+++ b/showcase.html
@@ -31,6 +31,10 @@
                                 <img src="media/starsmp/staricons/ice.png" alt="Star SMP">
                                 <span>Star SMP</span>
                             </a>
+                            <a href="astralites/">
+                                <img src="media/branding/logo.png" alt="Astralites">
+                                <span>Astralites</span>
+                            </a>
                         </div>
                     </li>
                     <li><a href="contact.html">Contact</a></li>
@@ -86,34 +90,29 @@
                     </div>
                     <div class="card-ice-edge"></div>
                 </div>
-                <div class="plugin-card coming-soon">
+                <!-- Astralites Plugin -->
+                <div class="plugin-card">
                     <div class="plugin-card-inner">
                         <div class="plugin-icon">
-                            <img src="media/branding/logo.png" alt="Coming Soon">
+                            <img src="media/branding/logo.png" alt="Astralites Icon">
                             <div class="icon-glow"></div>
                         </div>
                         <div class="plugin-content">
-                            <h3>New Plugin</h3>
-                            <p class="plugin-description">Exciting new projects sonn to be in development</p>
+                            <h3>Astralites</h3>
+                            <p class="plugin-description">A hardcore survival experience with a unique twist, featuring 18 unique stars.</p>
                             <div class="plugin-features">
-                                <span class="feature-tag">Coming Soon</span>
+                                <span class="feature-tag">PvP</span>
+                                <span class="feature-tag">Hardcore</span>
+                                <span class="feature-tag">Abilities</span>
                             </div>
                         </div>
-                        <div class="plugin-link disabled">
+                        <a href="astralites/" class="plugin-link">
                             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                                 <path d="M5 12h14M12 5l7 7-7 7"/>
                             </svg>
-                        </div>
+                        </a>
                     </div>
                     <div class="card-ice-edge"></div>
-                    <div class="coming-soon-overlay">
-                        <span>Coming Soon</span>
-                        <div class="snowflakes">
-                            <div class="snowflake">❅</div>
-                            <div class="snowflake">❆</div>
-                            <div class="snowflake">❅</div>
-                        </div>
-                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Adds a new showcase page for the Astralites plugin.

The new page is located at /astralites/ and includes a detailed description of the plugin's features, including the different star types and their abilities.

The showcase is linked from the main showcase page, replacing the "Coming Soon" placeholder. A new CSS file has been created to style the page, and existing media assets have been used.