### PR TITLE
feat: Add Astralites showcase page

### DIFF
--- a/astralites/index.html
+++ b/astralites/index.html
@@ -54,393 +54,381 @@
 
     <section class="star-categories">
         <div class="container">
-            <div class="category-tabs">
-                <button class="tab-btn active" data-category="annihilators">The Annihilators</button>
-                <button class="tab-btn" data-category="controllers">The Controllers</button>
-                <button class="tab-btn" data-category="harbingers">The Harbingers</button>
-            </div>
-
-            <div class="category-content active" id="annihilators">
-                <!-- SUPERNOVA STAR -->
-                <div class="star-card" data-star="supernova">
-                    <div class="star-header">
-                        <div class="star-name-container">
-                            <h2>SUPERNOVA STAR</h2>
-                        </div>
-                    </div>
-                    <div class="star-content">
-                        <div class="star-abilities">
-                            <div class="ability">
-                                <p>Become the heart of a dying star. You are a walking cataclysm, capable of unleashing one of the most destructive forces in the universe. But wield this power with caution, for its magnitude is matched only by its danger.</p>
-                                <h3>Ability: Cataclysmic Detonation</h3>
-                                <p>After a 5-second charge, you explode in a massive 15-block radius, dealing catastrophic damage (8-10 hearts) to all nearby entities.</p>
-                                <h3>Death Trigger</h3>
-                                <p>If you are killed while charging, your body becomes a martyr's bomb, triggering the supernova upon death.</p>
-                                <h3>Cooldown</h3>
-                                <p>This ultimate power can only be used once every 5 Minecraft days.</p>
-                            </div>
-                        </div>
-                        <div class="star-media">
-                            <div class="video-pair">
-                                <video controls>
-                                    <source src="../media/astralitessmp/SupernovaReplay.mp4" type="video/mp4">
-                                    Your browser does not support the video tag.
-                                </video>
-                                <p>Replay view</p>
-                            </div>
-                        </div>
+            <!-- SUPERNOVA STAR -->
+            <div class="star-card" data-star="supernova">
+                <div class="star-header">
+                    <div class="star-name-container">
+                        <h2>SUPERNOVA STAR</h2>
                     </div>
                 </div>
-
-                <!-- RAGNAROK STAR -->
-                <div class="star-card" data-star="ragnarok">
-                    <div class="star-header">
-                        <div class="star-name-container">
-                            <h2>RAGNAROK STAR</h2>
-                        </div>
-                    </div>
+                <div class="star-content">
                     <div class="star-abilities">
                         <div class="ability">
-                            <p>Unleash the end of days. For a brief, terrifying period, you become a harbinger of the apocalypse, tearing the world apart around you. This power comes at a great personal cost, chipping away at your very life force with each use.</p>
-                            <h3>Ability: The Final Hour</h3>
-                            <p>For 10 seconds, you summon a storm of destruction. Random lightning strikes and chaotic explosions erupt in a 12-block radius around you.</p>
-                            <h3>Ultimate Sacrifice</h3>
-                            <p>Each use of this ability permanently removes 1 heart from your maximum health.</p>
+                            <p>Become the heart of a dying star. You are a walking cataclysm, capable of unleashing one of the most destructive forces in the universe. But wield this power with caution, for its magnitude is matched only by its danger.</p>
+                            <h3>Ability: Cataclysmic Detonation</h3>
+                            <p>After a 5-second charge, you explode in a massive 15-block radius, dealing catastrophic damage (8-10 hearts) to all nearby entities.</p>
+                            <h3>Death Trigger</h3>
+                            <p>If you are killed while charging, your body becomes a martyr's bomb, triggering the supernova upon death.</p>
                             <h3>Cooldown</h3>
-                            <p>Can be used once every 2 Minecraft days.</p>
+                            <p>This ultimate power can only be used once every 5 Minecraft days.</p>
                         </div>
                     </div>
-                </div>
-
-                <!-- METEOR STAR -->
-                <div class="star-card" data-star="meteor">
-                    <div class="star-header">
-                        <div class="star-name-container">
-                            <h2>METEOR STAR</h2>
-                        </div>
-                    </div>
-                     <div class="star-content">
-                        <div class="star-abilities">
-                            <div class="ability">
-                                <p>Call down the heavens' wrath. Command a volley of celestial rocks to bombard your enemies from above, turning the battlefield into a cratered wasteland.</p>
-                                <h3>Ability: Meteor Shower</h3>
-                                <p>Summons 3-5 small meteors that crash down randomly in a 10-block radius around your target.</p>
-                                <h3>Impact</h3>
-                                <p>Each meteor deals 2.5 hearts on direct hit and explodes with the force of a small creeper blast, potentially setting the ground ablaze.</p>
-                                <h3>Cooldown</h3>
-                                <p>50 seconds.</p>
-                            </div>
-                        </div>
-                        <div class="star-media">
-                            <div class="video-pair">
-                                <video controls>
-                                    <source src="../media/astralitessmp/MeteorReplay.mp4" type="video/mp4">
-                                    Your browser does not support the video tag.
-                                </video>
-                                <p>Replay view</p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- BURN STAR -->
-                <div class="star-card" data-star="burn">
-                    <div class="star-header">
-                        <div class="star-name-container">
-                            <h2>BURN STAR</h2>
-                        </div>
-                    </div>
-                    <div class="star-abilities">
-                        <div class="ability">
-                            <p>Embody the eternal flame. You are a living inferno. Summon a searing explosion and walk through fire as if it were air, your power waxing in the light of the sun.</p>
-                            <h3>Ability: Fire Nova</h3>
-                            <p>Unleash a fiery explosion in a 6-block radius, dealing 3-4 hearts of damage and setting everything ablaze with a Fire Aspect II burn.</p>
-                            <h3>User Buffs</h3>
-                            <p>For 10 seconds after activation, you are immune to fire and lava. Additionally, you deal 20% increased melee damage while in direct daylight.</p>
-                            <h3>Cooldown</h3>
-                            <p>45 seconds.</p>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- SUNLIGHT STAR -->
-                <div class="star-card" data-star="sunlight">
-                    <div class="star-header">
-                        <div class="star-name-container">
-                            <h2>SUNLIGHT STAR</h2>
-                        </div>
-                    </div>
-                    <div class="star-abilities">
-                        <div class="ability">
-                            <p>Wield a beam of pure solar energy. Fire a concentrated laser of sunlight that pierces through your foes, leaving them scorched and blinded by your brilliance.</p>
-                            <h3>Ability: Solar Beam</h3>
-                            <p>Fires a 20-block laser that pierces up to three enemies, dealing a massive 6 hearts of damage and inflicting Blindness for 30 seconds.</p>
-                            <h3>Sunlight Affinity</h3>
-                            <p>The ability's cooldown charges 50% faster when you are standing in direct sunlight.</p>
-                            <h3>Cooldown</h3>
-                            <p>40 seconds.</p>
+                    <div class="star-media">
+                        <div class="video-pair">
+                            <video controls>
+                                <source src="../media/astralitessmp/SupernovaReplay.mp4" type="video/mp4">
+                                Your browser does not support the video tag.
+                            </video>
+                            <p>Replay view</p>
                         </div>
                     </div>
                 </div>
             </div>
 
-            <div class="category-content" id="controllers">
-                <!-- STAR WARDEN -->
-                <div class="star-card" data-star="starwarden">
-                    <div class="star-header">
-                        <div class="star-name-container">
-                            <h2>STAR WARDEN</h2>
-                        </div>
+            <!-- METEOR STAR -->
+            <div class="star-card" data-star="meteor">
+                <div class="star-header">
+                    <div class="star-name-container">
+                        <h2>METEOR STAR</h2>
                     </div>
+                </div>
+                 <div class="star-content">
                     <div class="star-abilities">
                         <div class="ability">
-                            <p>Command the irresistible pull of a black hole. You bend gravity to your will, creating a singularity that traps your enemies and tears them apart.</p>
-                            <h3>Ability: Event Horizon</h3>
-                            <p>For 15 seconds, create a black hole that pulls in mobs, players, projectiles, and items within a 30-block radius. Anything caught in the epicenter takes a devastating 10 hearts of damage per second.</p>
-                            <h3>User Buffs</h3>
-                            <p>You take 75% less fall damage, but your own gravitational pull causes you to fall 25% faster.</p>
+                            <p>Call down the heavens' wrath. Command a volley of celestial rocks to bombard your enemies from above, turning the battlefield into a cratered wasteland.</p>
+                            <h3>Ability: Meteor Shower</h3>
+                            <p>Summons 3-5 small meteors that crash down randomly in a 10-block radius around your target.</p>
+                            <h3>Impact</h3>
+                            <p>Each meteor deals 2.5 hearts on direct hit and explodes with the force of a small creeper blast, potentially setting the ground ablaze.</p>
+                            <h3>Cooldown</h3>
+                            <p>50 seconds.</p>
+                        </div>
+                    </div>
+                    <div class="star-media">
+                        <div class="video-pair">
+                            <video controls>
+                                <source src="../media/astralitessmp/MeteorReplay.mp4" type="video/mp4">
+                                Your browser does not support the video tag.
+                            </video>
+                            <p>Replay view</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- FREEZE STAR -->
+            <div class="star-card" data-star="freeze">
+                <div class="star-header">
+                    <div class="star-name-container">
+                        <h2>FREEZE STAR</h2>
+                    </div>
+                </div>
+                 <div class="star-content">
+                    <div class="star-abilities">
+                        <div class="ability">
+                            <p>Stop your enemy in the river of time. Isolate a single foe, locking them in a timeless prison. They are safe from harm while frozen, but once time resumes, the entirety of their deferred fate is dealt at once.</p>
+                            <h3>Ability: Time Lock</h3>
+                            <p>Target an enemy within 15 blocks, freezing them for 5 seconds. The target is invulnerable but cannot move or act. All damage they would have taken is queued and applied instantly when the effect ends.</p>
+                            <h3>Cooldown</h3>
+                            <p>15 seconds.</p>
+                        </div>
+                    </div>
+                    <div class="star-media">
+                        <div class="video-pair">
+                            <video controls>
+                                <source src="../media/astralitessmp/FreezeReplay.mp4" type="video/mp4">
+                                Your browser does not support the video tag.
+                            </video>
+                            <p>Replay view</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- CRUSH STAR -->
+            <div class="star-card" data-star="crush">
+                <div class="star-header">
+                    <div class="star-name-container">
+                        <h2>CRUSH STAR</h2>
+                    </div>
+                </div>
+                <div class="star-content">
+                    <div class="star-abilities">
+                        <div class="ability">
+                            <p>Dominate your personal space with gravitational force. First, you pull all nearby foes into your grasp, then you violently expel them, using gravity as both a net and a hammer.</p>
+                            <h3>Ability: Pull and Repel</h3>
+                            <p>A two-step ability. First, all enemies within a 12-block radius are dragged towards you for 2 seconds. This is immediately followed by a violent knockback, launching them 8 blocks away and inflicting 2 hearts of fall damage.</p>
+                            <h3>Cooldown</h3>
+                            <p>50 seconds.</p>
+                        </div>
+                    </div>
+                    <div class="star-media">
+                        <div class="video-pair">
+                            <video controls>
+                                <source src="../media/astralitessmp/CrushReplay.mp4" type="video/mp4">
+                                Your browser does not support the video tag.
+                            </video>
+                            <p>Replay view</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- CHAOS STAR -->
+            <div class="star-card" data-star="chaos">
+                <div class="star-header">
+                    <div class="star-name-container">
+                        <h2>CHAOS STAR</h2>
+                    </div>
+                </div>
+                <div class="star-content">
+                    <div class="star-abilities">
+                        <div class="ability">
+                            <p>Embrace total randomness. Be the agent of cosmic uncertainty. Each activation is a gamble. Will you shower the world with riches, summon a powerful ally, or unleash a terrible monster upon yourself and your enemies?</p>
+                            <h3>Ability: Roll the Dice</h3>
+                            <p>When activated, a random event occurs:</p>
+                            <ul>
+                                <li>30% Chance: Spawn random valuable loot.</li>
+                                <li>30% Chance: Summon random hostile or friendly mobs.</li>
+                                <li>20% Chance: Apply random potion effects to everyone nearby.</li>
+                                <li>15% Chance: Create a dangerous anomaly, like a TNT explosion or lightning strike.</li>
+                                <li>5% Chance: Spawn a Warden.</li>
+                            </ul>
                             <h3>Cooldown</h3>
                             <p>60 seconds.</p>
                         </div>
                     </div>
-                </div>
-
-                <!-- NEBULA STAR -->
-                <div class="star-card" data-star="nebula">
-                    <div class="star-header">
-                        <div class="star-name-container">
-                            <h2>NEBULA STAR</h2>
-                        </div>
-                    </div>
-                    <div class="star-abilities">
-                        <div class="ability">
-                            <p>Become a living storm of cosmic dust. Shroud yourself in a swirling nebula that confounds and withers your enemies, making you a fortress against projectiles.</p>
-                            <h3>Ability: Ender's Mist</h3>
-                            <p>For 12 seconds, you are surrounded by a 7-block wide fog. Enemies inside are afflicted with Slowness II, Blindness, and Wither I. All enemy projectiles that enter the mist are nullified.</p>
-                            <h3>Downside</h3>
-                            <p>Your movement speed is reduced by 20% while the nebula is active.</p>
-                            <h3>Cooldown</h3>
-                            <p>45 seconds.</p>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- FREEZE STAR -->
-                <div class="star-card" data-star="freeze">
-                    <div class="star-header">
-                        <div class="star-name-container">
-                            <h2>FREEZE STAR</h2>
-                        </div>
-                    </div>
-                     <div class="star-content">
-                        <div class="star-abilities">
-                            <div class="ability">
-                                <p>Stop your enemy in the river of time. Isolate a single foe, locking them in a timeless prison. They are safe from harm while frozen, but once time resumes, the entirety of their deferred fate is dealt at once.</p>
-                                <h3>Ability: Time Lock</h3>
-                                <p>Target an enemy within 15 blocks, freezing them for 5 seconds. The target is invulnerable but cannot move or act. All damage they would have taken is queued and applied instantly when the effect ends.</p>
-                                <h3>Cooldown</h3>
-                                <p>15 seconds.</p>
-                            </div>
-                        </div>
-                        <div class="star-media">
-                            <div class="video-pair">
-                                <video controls>
-                                    <source src="../media/astralitessmp/FreezeReplay.mp4" type="video/mp4">
-                                    Your browser does not support the video tag.
-                                </video>
-                                <p>Replay view</p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- CRUSH STAR -->
-                <div class="star-card" data-star="crush">
-                    <div class="star-header">
-                        <div class="star-name-container">
-                            <h2>CRUSH STAR</h2>
-                        </div>
-                    </div>
-                    <div class="star-content">
-                        <div class="star-abilities">
-                            <div class="ability">
-                                <p>Dominate your personal space with gravitational force. First, you pull all nearby foes into your grasp, then you violently expel them, using gravity as both a net and a hammer.</p>
-                                <h3>Ability: Pull and Repel</h3>
-                                <p>A two-step ability. First, all enemies within a 12-block radius are dragged towards you for 2 seconds. This is immediately followed by a violent knockback, launching them 8 blocks away and inflicting 2 hearts of fall damage.</p>
-                                <h3>Cooldown</h3>
-                                <p>50 seconds.</p>
-                            </div>
-                        </div>
-                        <div class="star-media">
-                            <div class="video-pair">
-                                <video controls>
-                                    <source src="../media/astralitessmp/CrushReplay.mp4" type="video/mp4">
-                                    Your browser does not support the video tag.
-                                </video>
-                                <p>Replay view</p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- SOLAR STAR -->
-                <div class="star-card" data-star="solar">
-                    <div class="star-header">
-                        <div class="star-name-container">
-                            <h2>SOLAR STAR</h2>
-                        </div>
-                    </div>
-                    <div class="star-abilities">
-                        <div class="ability">
-                            <p>Unleash a blinding flash of stellar light. A close-range defensive burst, perfect for disorienting aggressive enemies and creating an opportunity to escape or counter-attack.</p>
-                            <h3>Ability: Solar Flare</h3>
-                            <p>Erupt with a flash of light in a 6-block radius. It deals 1 heart of damage but inflicts nearby enemies with Blindness (5s) and Nausea (4s).</p>
-                            <h3>Cooldown</h3>
-                            <p>30 seconds.</p>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- SKY STAR -->
-                <div class="star-card" data-star="sky">
-                    <div class="star-header">
-                        <div class="star-name-container">
-                            <h2>SKY STAR</h2>
-                        </div>
-                    </div>
-                    <div class="star-abilities">
-                        <div class="ability">
-                            <p>Defy gravity only to come crashing down with immense force. Use the sky as your perch before slamming into the ground, sending a shockwave that devastates your foes.</p>
-                            <h3>Ability: Celestial Slam</h3>
-                            <p>Launch yourself 15 blocks into the air. Upon landing, you create a 6-block shockwave that deals 4-6 hearts of damage and knocks back all nearby enemies by 5 blocks.</p>
-                            <h3>Cooldown</h3>
-                            <p>35 seconds.</p>
+                    <div class="star-media">
+                        <div class="video-pair">
+                            <video controls>
+                                <source src="../media/astralitessmp/ChaosReplay.mp4" type="video/mp4">
+                                Your browser does not support the video tag.
+                            </video>
+                            <p>Replay view</p>
                         </div>
                     </div>
                 </div>
             </div>
 
-            <div class="category-content" id="harbingers">
-                <!-- CHAOS STAR -->
-                <div class="star-card" data-star="chaos">
-                    <div class="star-header">
-                        <div class="star-name-container">
-                            <h2>CHAOS STAR</h2>
-                        </div>
-                    </div>
-                    <div class="star-content">
-                        <div class="star-abilities">
-                            <div class="ability">
-                                <p>Embrace total randomness. Be the agent of cosmic uncertainty. Each activation is a gamble. Will you shower the world with riches, summon a powerful ally, or unleash a terrible monster upon yourself and your enemies?</p>
-                                <h3>Ability: Roll the Dice</h3>
-                                <p>When activated, a random event occurs:</p>
-                                <ul>
-                                    <li>30% Chance: Spawn random valuable loot.</li>
-                                    <li>30% Chance: Summon random hostile or friendly mobs.</li>
-                                    <li>20% Chance: Apply random potion effects to everyone nearby.</li>
-                                    <li>15% Chance: Create a dangerous anomaly, like a TNT explosion or lightning strike.</li>
-                                    <li>5% Chance: Spawn a Warden.</li>
-                                </ul>
-                                <h3>Cooldown</h3>
-                                <p>60 seconds.</p>
-                            </div>
-                        </div>
-                        <div class="star-media">
-                            <div class="video-pair">
-                                <video controls>
-                                    <source src="../media/astralitessmp/ChaosReplay.mp4" type="video/mp4">
-                                    Your browser does not support the video tag.
-                                </video>
-                                <p>Replay view</p>
-                            </div>
-                        </div>
+            <!-- LIFELEECH STAR -->
+            <div class="star-card" data-star="lifeleech">
+                <div class="star-header">
+                    <div class="star-name-container">
+                        <h2>LIFELEECH STAR</h2>
                     </div>
                 </div>
-
-                <!-- PACT STAR -->
-                <div class="star-card" data-star="pact">
-                    <div class="star-header">
-                        <div class="star-name-container">
-                            <h2>PACT STAR</h2>
-                        </div>
-                    </div>
+                <div class="star-content">
                     <div class="star-abilities">
                         <div class="ability">
-                            <p>Make a blood pact for overwhelming power. Sacrifice your own life force for a brief window of godlike damage. Your only path to recovery is through victory.</p>
-                            <h3>Ability: Blood for Power</h3>
-                            <p>Instantly sacrifice 3 of your hearts to deal double damage for 10 seconds.</p>
-                            <h3>Reaping Clause</h3>
-                            <p>If you kill a player while the buff is active, your sacrificed hearts are immediately restored.</p>
+                            <p>Become a vampiric warrior, sustained by the vitality of your foes. This power allows you to drain health with every blow, but such dark magic constantly saps your own energy.</p>
+                            <h3>Ability: Vampiric Strikes</h3>
+                            <p>For 12 seconds, every melee hit you land steals 1.5 hearts from your enemy and heals you for the same amount.</p>
+                            <h3>Downside</h3>
+                            <p>While active, your hunger drains rapidly (1 bar every 4 seconds).</p>
                             <h3>Cooldown</h3>
-                            <p>65 seconds.</p>
+                            <p>70 seconds.</p>
+                        </div>
+                    </div>
+                    <div class="star-media">
+                        <div class="video-pair">
+                            <video controls>
+                                <source src="../media/astralitessmp/LifeLeechStar.mp4" type="video/mp4">
+                                Your browser does not support the video tag.
+                            </video>
+                            <p>Replay view</p>
                         </div>
                     </div>
                 </div>
+            </div>
 
-                <!-- MIRROR STAR -->
-                <div class="star-card" data-star="mirror">
-                    <div class="star-header">
-                        <div class="star-name-container">
-                            <h2>MIRROR STAR</h2>
-                        </div>
-                    </div>
-                    <div class="star-abilities">
-                        <div class="ability">
-                            <p>Turn your enemy's strength against them. For a short duration, you become a reflective shield. A portion of all damage you take is instantly sent back to its source, with a chance to punish them even harder.</p>
-                            <h3>Ability: Damage Reversal</h3>
-                            <p>For 5 seconds, 50% of all incoming damage is reflected back to the attacker. There is a 20% chance that the reflected damage is doubled.</p>
-                            <h3>Cooldown</h3>
-                            <p>55 seconds.</p>
-                        </div>
+            <!-- RAGNAROK STAR -->
+            <div class="star-card" data-star="ragnarok">
+                <div class="star-header">
+                    <div class="star-name-container">
+                        <h2>RAGNAROK STAR</h2>
                     </div>
                 </div>
-
-                <!-- GRIMOIRE STAR -->
-                <div class="star-card" data-star="grimoire">
-                    <div class="star-header">
-                        <div class="star-name-container">
-                            <h2>GRIMOIRE STAR</h2>
-                        </div>
-                    </div>
-                    <div class="star-abilities">
-                        <div class="ability">
-                            <p>Wield a cursed book of unpredictable magic. You attempt to cast debilitating curses on your foes, but the Grimoire is fickle. There's an equal chance its chaotic magic will empower them instead.</p>
-                            <h3>Ability: Unstable Hex</h3>
-                            <p>Affects all enemies in an 8-block radius with random potion effects. There is a 50% chance the effects are harmful (e.g., Poison II, Slowness) and a 50% chance they are beneficial (e.g., Strength, Speed).</p>
-                            <h3>Cooldown</h3>
-                            <p>40 seconds.</p>
-                        </div>
+                <div class="star-abilities">
+                    <div class="ability">
+                        <p>Unleash the end of days. For a brief, terrifying period, you become a harbinger of the apocalypse, tearing the world apart around you. This power comes at a great personal cost, chipping away at your very life force with each use.</p>
+                        <h3>Ability: The Final Hour</h3>
+                        <p>For 10 seconds, you summon a storm of destruction. Random lightning strikes and chaotic explosions erupt in a 12-block radius around you.</p>
+                        <h3>Ultimate Sacrifice</h3>
+                        <p>Each use of this ability permanently removes 1 heart from your maximum health.</p>
+                        <h3>Cooldown</h3>
+                        <p>Can be used once every 2 Minecraft days.</p>
                     </div>
                 </div>
+            </div>
 
-                <!-- LIFELEECH STAR -->
-                <div class="star-card" data-star="lifeleech">
-                    <div class="star-header">
-                        <div class="star-name-container">
-                            <h2>LIFELEECH STAR</h2>
-                        </div>
+            <!-- BURN STAR -->
+            <div class="star-card" data-star="burn">
+                <div class="star-header">
+                    <div class="star-name-container">
+                        <h2>BURN STAR</h2>
                     </div>
-                    <div class="star-content">
-                        <div class="star-abilities">
-                            <div class="ability">
-                                <p>Become a vampiric warrior, sustained by the vitality of your foes. This power allows you to drain health with every blow, but such dark magic constantly saps your own energy.</p>
-                                <h3>Ability: Vampiric Strikes</h3>
-                                <p>For 12 seconds, every melee hit you land steals 1.5 hearts from your enemy and heals you for the same amount.</p>
-                                <h3>Downside</h3>
-                                <p>While active, your hunger drains rapidly (1 bar every 4 seconds).</p>
-                                <h3>Cooldown</h3>
-                                <p>70 seconds.</p>
-                            </div>
-                        </div>
-                        <div class="star-media">
-                            <div class="video-pair">
-                                <video controls>
-                                    <source src="../media/astralitessmp/LifeLeechStar.mp4" type="video/mp4">
-                                    Your browser does not support the video tag.
-                                </video>
-                                <p>Replay view</p>
-                            </div>
-                        </div>
+                </div>
+                <div class="star-abilities">
+                    <div class="ability">
+                        <p>Embody the eternal flame. You are a living inferno. Summon a searing explosion and walk through fire as if it were air, your power waxing in the light of the sun.</p>
+                        <h3>Ability: Fire Nova</h3>
+                        <p>Unleash a fiery explosion in a 6-block radius, dealing 3-4 hearts of damage and setting everything ablaze with a Fire Aspect II burn.</p>
+                        <h3>User Buffs</h3>
+                        <p>For 10 seconds after activation, you are immune to fire and lava. Additionally, you deal 20% increased melee damage while in direct daylight.</p>
+                        <h3>Cooldown</h3>
+                        <p>45 seconds.</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- SUNLIGHT STAR -->
+            <div class="star-card" data-star="sunlight">
+                <div class="star-header">
+                    <div class="star-name-container">
+                        <h2>SUNLIGHT STAR</h2>
+                    </div>
+                </div>
+                <div class="star-abilities">
+                    <div class="ability">
+                        <p>Wield a beam of pure solar energy. Fire a concentrated laser of sunlight that pierces through your foes, leaving them scorched and blinded by your brilliance.</p>
+                        <h3>Ability: Solar Beam</h3>
+                        <p>Fires a 20-block laser that pierces up to three enemies, dealing a massive 6 hearts of damage and inflicting Blindness for 30 seconds.</p>
+                        <h3>Sunlight Affinity</h3>
+                        <p>The ability's cooldown charges 50% faster when you are standing in direct sunlight.</p>
+                        <h3>Cooldown</h3>
+                        <p>40 seconds.</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- STAR WARDEN -->
+            <div class="star-card" data-star="starwarden">
+                <div class="star-header">
+                    <div class="star-name-container">
+                        <h2>STAR WARDEN</h2>
+                    </div>
+                </div>
+                <div class="star-abilities">
+                    <div class="ability">
+                        <p>Command the irresistible pull of a black hole. You bend gravity to your will, creating a singularity that traps your enemies and tears them apart.</p>
+                        <h3>Ability: Event Horizon</h3>
+                        <p>For 15 seconds, create a black hole that pulls in mobs, players, projectiles, and items within a 30-block radius. Anything caught in the epicenter takes a devastating 10 hearts of damage per second.</p>
+                        <h3>User Buffs</h3>
+                        <p>You take 75% less fall damage, but your own gravitational pull causes you to fall 25% faster.</p>
+                        <h3>Cooldown</h3>
+                        <p>60 seconds.</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- NEBULA STAR -->
+            <div class="star-card" data-star="nebula">
+                <div class="star-header">
+                    <div class="star-name-container">
+                        <h2>NEBULA STAR</h2>
+                    </div>
+                </div>
+                <div class="star-abilities">
+                    <div class="ability">
+                        <p>Become a living storm of cosmic dust. Shroud yourself in a swirling nebula that confounds and withers your enemies, making you a fortress against projectiles.</p>
+                        <h3>Ability: Ender's Mist</h3>
+                        <p>For 12 seconds, you are surrounded by a 7-block wide fog. Enemies inside are afflicted with Slowness II, Blindness, and Wither I. All enemy projectiles that enter the mist are nullified.</p>
+                        <h3>Downside</h3>
+                        <p>Your movement speed is reduced by 20% while the nebula is active.</p>
+                        <h3>Cooldown</h3>
+                        <p>45 seconds.</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- SOLAR STAR -->
+            <div class="star-card" data-star="solar">
+                <div class="star-header">
+                    <div class="star-name-container">
+                        <h2>SOLAR STAR</h2>
+                    </div>
+                </div>
+                <div class="star-abilities">
+                    <div class="ability">
+                        <p>Unleash a blinding flash of stellar light. A close-range defensive burst, perfect for disorienting aggressive enemies and creating an opportunity to escape or counter-attack.</p>
+                        <h3>Ability: Solar Flare</h3>
+                        <p>Erupt with a flash of light in a 6-block radius. It deals 1 heart of damage but inflicts nearby enemies with Blindness (5s) and Nausea (4s).</p>
+                        <h3>Cooldown</h3>
+                        <p>30 seconds.</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- SKY STAR -->
+            <div class="star-card" data-star="sky">
+                <div class="star-header">
+                    <div class="star-name-container">
+                        <h2>SKY STAR</h2>
+                    </div>
+                </div>
+                <div class="star-abilities">
+                    <div class="ability">
+                        <p>Defy gravity only to come crashing down with immense force. Use the sky as your perch before slamming into the ground, sending a shockwave that devastates your foes.</p>
+                        <h3>Ability: Celestial Slam</h3>
+                        <p>Launch yourself 15 blocks into the air. Upon landing, you create a 6-block shockwave that deals 4-6 hearts of damage and knocks back all nearby enemies by 5 blocks.</p>
+                        <h3>Cooldown</h3>
+                        <p>35 seconds.</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- PACT STAR -->
+            <div class="star-card" data-star="pact">
+                <div class="star-header">
+                    <div class="star-name-container">
+                        <h2>PACT STAR</h2>
+                    </div>
+                </div>
+                <div class="star-abilities">
+                    <div class="ability">
+                        <p>Make a blood pact for overwhelming power. Sacrifice your own life force for a brief window of godlike damage. Your only path to recovery is through victory.</p>
+                        <h3>Ability: Blood for Power</h3>
+                        <p>Instantly sacrifice 3 of your hearts to deal double damage for 10 seconds.</p>
+                        <h3>Reaping Clause</h3>
+                        <p>If you kill a player while the buff is active, your sacrificed hearts are immediately restored.</p>
+                        <h3>Cooldown</h3>
+                        <p>65 seconds.</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- MIRROR STAR -->
+            <div class="star-card" data-star="mirror">
+                <div class="star-header">
+                    <div class="star-name-container">
+                        <h2>MIRROR STAR</h2>
+                    </div>
+                </div>
+                <div class="star-abilities">
+                    <div class="ability">
+                        <p>Turn your enemy's strength against them. For a short duration, you become a reflective shield. A portion of all damage you take is instantly sent back to its source, with a chance to punish them even harder.</p>
+                        <h3>Ability: Damage Reversal</h3>
+                        <p>For 5 seconds, 50% of all incoming damage is reflected back to the attacker. There is a 20% chance that the reflected damage is doubled.</p>
+                        <h3>Cooldown</h3>
+                        <p>55 seconds.</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- GRIMOIRE STAR -->
+            <div class="star-card" data-star="grimoire">
+                <div class="star-header">
+                    <div class="star-name-container">
+                        <h2>GRIMOIRE STAR</h2>
+                    </div>
+                </div>
+                <div class="star-abilities">
+                    <div class="ability">
+                        <p>Wield a cursed book of unpredictable magic. You attempt to cast debilitating curses on your foes, but the Grimoire is fickle. There's an equal chance its chaotic magic will empower them instead.</p>
+                        <h3>Ability: Unstable Hex</h3>
+                        <p>Affects all enemies in an 8-block radius with random potion effects. There is a 50% chance the effects are harmful (e.g., Poison II, Slowness) and a 50% chance they are beneficial (e.g., Strength, Speed).</p>
+                        <h3>Cooldown</h3>
+                        <p>40 seconds.</p>
                     </div>
                 </div>
             </div>

--- a/showcase.html
+++ b/showcase.html
@@ -114,6 +114,35 @@
                     </div>
                     <div class="card-ice-edge"></div>
                 </div>
+                <div class="plugin-card coming-soon">
+                    <div class="plugin-card-inner">
+                        <div class="plugin-icon">
+                            <img src="media/branding/logo.png" alt="Coming Soon">
+                            <div class="icon-glow"></div>
+                        </div>
+                        <div class="plugin-content">
+                            <h3>New Plugin</h3>
+                            <p class="plugin-description">Exciting new projects sonn to be in development</p>
+                            <div class="plugin-features">
+                                <span class="feature-tag">Coming Soon</span>
+                            </div>
+                        </div>
+                        <div class="plugin-link disabled">
+                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M5 12h14M12 5l7 7-7 7"/>
+                            </svg>
+                        </div>
+                    </div>
+                    <div class="card-ice-edge"></div>
+                    <div class="coming-soon-overlay">
+                        <span>Coming Soon</span>
+                        <div class="snowflakes">
+                            <div class="snowflake">❅</div>
+                            <div class="snowflake">❆</div>
+                            <div class="snowflake">❅</div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </section>


### PR DESCRIPTION
Adds a new showcase page for the Astralites plugin.

The new page is located at /astralites/ and includes a detailed description of the plugin's features, including the different star types and their abilities.

The showcase is linked from the main showcase page, and the "Coming Soon" placeholder has been preserved. The stars on the Astralites page are now in a single list, with stars that have video demos appearing first.